### PR TITLE
Update Porsche Panamera generations: corrected first generation start year

### DIFF
--- a/generations.yaml
+++ b/generations.yaml
@@ -3,7 +3,7 @@ references:
 
 generations:
   - name: "First Generation (970)"
-    start_year: 2010
+    start_year: 2009
     end_year: 2016
     description: "The first-generation Porsche Panamera (970) marked Porsche's entry into the four-door luxury sports sedan segment. Designed as a grand tourer with 911-inspired styling cues adapted to a four-door format, the Panamera offered 2+2 seating in a hatchback body style. Initially available with naturally aspirated 4.8-liter V8 (Panamera S/4S) and twin-turbocharged 4.8-liter V8 (Panamera Turbo) engines, the range later expanded to include V6 models, diesel variants, and the hybrid Panamera S E-Hybrid. Power outputs ranged from 300 horsepower in the base V6 to 570 horsepower in the Turbo S. Most models featured a seven-speed PDK dual-clutch transmission, though some markets received manual and conventional automatic options. Despite controversial styling—particularly its bulbous rear end designed to accommodate rear passenger headroom—the Panamera was praised for combining sports car handling with luxury sedan comfort. The interior featured a distinctive center console design with a wide array of physical buttons and controls, premium materials, and advanced technology for its time. A facelift in 2013 refined the exterior design, particularly improving the rear-end styling, while adding the long-wheelbase Executive model for markets prioritizing rear-seat comfort. The first-generation Panamera successfully created a new segment for Porsche, appealing to buyers seeking Porsche driving dynamics without sacrificing practicality."
 


### PR DESCRIPTION
- Changed start_year from 2010 to 2009 for First Generation (970)
- Wikipedia article confirms production began April 2009 at Shanghai Auto Show
- Section titled "First generation (970 Chassis G1; 2009)" confirms the 2009 start date
- Vehicle debuted April 2009, though some markets may have received it as 2010 model year
